### PR TITLE
Use system.net.http from gac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ environment.sh
 .DS_Store
 .idea/
 /src/Notify.Tests/Notify.Tests.csproj.user
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.7.1] - 2021-05-04
+
+* Use System.Net.Http from the GAC when the project is compiled as .net framework.
+
 ## [2.7.0] - 2020-11-18
 
 * The Notification class has a new `createdByEmailAddress` property.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ docker build -t fsnetcore .
 You can then run tests or anything else through docker as follows:
 
 ```
-docker run -v (pwd):/src -w /src --env-file .env -it fsnetcore [COMMAND]
+docker run -v $(pwd):/src -w /src --env-file .env -it fsnetcore [COMMAND]
 
-docker run -v (pwd):/src -w /src --env-file .env -it fsnetcore make build
-docker run -v (pwd):/src -w /src --env-file .env -it fsnetcore make build-test
-docker run -v (pwd):/src -w /src --env-file .env -it fsnetcore make build-package
+docker run -v $(pwd):/src -w /src --env-file .env -it fsnetcore make build
+docker run -v $(pwd):/src -w /src --env-file .env -it fsnetcore make build-test
+docker run -v $(pwd):/src -w /src --env-file .env -it fsnetcore make build-package
 ```
 
 ## Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM fsharp:netcore
+FROM fsharp:10.2.3-netcore
 
 RUN apt-get update && apt-get --no-install-recommends install -y make

--- a/src/Notify.Tests/Notify.Tests.csproj
+++ b/src/Notify.Tests/Notify.Tests.csproj
@@ -19,4 +19,8 @@
     <ProjectReference Include="..\Notify\Notify.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
 </Project>

--- a/src/Notify/Notify.csproj
+++ b/src/Notify/Notify.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
-    <Version>2.7.0</Version>
+    <Version>2.7.1</Version>
     <Authors>Notify.gov.au, GOV.UK Notify</Authors>
     <Owners>Notify.gov.au</Owners>
     <Description>Notify.gov.au .NET client</Description>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What problem does the pull request solve?
Use System.net.http from the GAC when it is compiled as .net framework.
Also pin the version of  fsharp in dockerfile.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->
- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve update the documentation (in `DOCUMENATION.md` and `CHANGELOG.md`)
- [x] I’ve bumped the version number (in `src/Notify/Notify.csproj`)
